### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -4,6 +4,9 @@ on:
   push:
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/jtremesay/camille/security/code-scanning/1](https://github.com/jtremesay/camille/security/code-scanning/1)

Add an explicit top-level `permissions` block in `.github/workflows/main.yaml` so all jobs inherit least-privilege defaults. The minimal safe baseline recommended by CodeQL is:

- `contents: read`

This preserves existing workflow behavior while documenting and constraining token access. Since no shown step clearly requires additional GitHub write scopes (like `pull-requests: write`), start with read-only contents at workflow root. If later a job fails due to missing token scopes, add only the specific extra permission at that job level.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
